### PR TITLE
feat: Support latest Intellij products 2025.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ You can find the plugin on [IntelliJ marketplace](https://plugins.jetbrains.com/
 
 Manually verified with these products…
 
-- IntelliJ IDEA Community Edition 2025.1+
-- IntelliJ IDEA Ultimate 2025.1+
-- PhpStorm 2025.1+
-- WebStorm 2025.1+
+- IntelliJ IDEA Community Edition 2025.2+
+- IntelliJ IDEA Ultimate 2025.2+
+- PhpStorm 2025.2+
+- WebStorm 2025.2+
 
 ## ❤️🙏 Love & Thanks
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ fun properties(key: String) = providers.gradleProperty(key)
 
 plugins {
     id("java")
-    id("org.jetbrains.kotlin.jvm") version "2.0.10"
+    id("org.jetbrains.kotlin.jvm") version "2.2.0"
     id("org.jetbrains.intellij.platform") version "2.5.0"
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,10 +8,10 @@ org.gradle.caching=true
 pluginName=html-attribute-folder
 pluginGroup=dev.zbinski
 pluginVersion=1.2.0
-platformVersion=2025.1
+platformVersion=2025.2
 # @see https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-types.html#IntelliJPlatformType
 platformType=IC
 # @see https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html#platformVersions
-pluginSinceBuild=251
-pluginUntilBuild=251.*
+pluginSinceBuild=252
+pluginUntilBuild=252.*
 javaVersion=21

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ org.gradle.caching=true
 
 pluginName=html-attribute-folder
 pluginGroup=dev.zbinski
-pluginVersion=1.2.0
+pluginVersion=1.3.0
 platformVersion=2025.2
 # @see https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-types.html#IntelliJPlatformType
 platformType=IC

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -7,7 +7,7 @@
          Guidelines: https://plugins.jetbrains.com/docs/marketplace/plugin-overview-page.html#plugin-name -->
     <name>HTML Attribute Folder</name>
 
-    <version>1.2.0</version>
+    <version>1.3.0</version>
 
     <!-- A displayed Vendor name or Organization ID displayed on the Plugins Page. -->
     <vendor email="dawid@zbinski.dev" url="https://zbinski.dev">Dawid Zbiński</vendor>


### PR DESCRIPTION
- Runs with latest Intellij products (2025.2+)
- Update list of compatible products
- Increase version of plugin to 1.3.0